### PR TITLE
非推奨になったReactDOM.renderの代わりにcreateRootを使うよう修正

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import App from './app';
 
 import './style.scss';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+  throw new Error('Failed to find the root element.');
+}
+
+const root = createRoot(rootElement);
+root.render(<App />);


### PR DESCRIPTION
https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis